### PR TITLE
Updated KnetMiners concept legend 

### DIFF
--- a/common/client-base/src/main/webapp/html/KnetMaps/css/knet-style.css
+++ b/common/client-base/src/main/webapp/html/KnetMaps/css/knet-style.css
@@ -268,6 +268,6 @@ input.knetCon_Trait_Ontology { border: none; width:22px; height:22px; background
      }
 
      .icon_caption {
-      display: block;/*float:left;*/
-	  font-size: 12px;
+      display: block;/*float:below;*/
+	  font-size: 11.5px;
      }      

--- a/common/client-base/src/main/webapp/html/KnetMaps/javascript/knet-conceptsLegend.js
+++ b/common/client-base/src/main/webapp/html/KnetMaps/javascript/knet-conceptsLegend.js
@@ -1,20 +1,14 @@
 var KNETMAPS = KNETMAPS || {};
-
 KNETMAPS.ConceptsLegend = function () {
 
     var stats = KNETMAPS.Stats();
-
-
     var my = function () {};
-
-
     my.conName = function (conText) {
-        
         // Map the concept names to corresponding legend context names
-        map = {"Biological_Process" : "BioProc", "Molecular_Function" : "MolFunc",
-                "Cellular_Component" : "CellComp", "Trait Ontology" : "TO",
-                "PlantOntologyTerm" : "PO", "Enzyme Classification" : "EC",
-                "Quantitative Trait Locus" : "QTL", "Protein Domain" : "Domain"};
+        map = {"Biological_Process": "BioProc", "Molecular_Function": "MolFunc",
+            "Cellular_Component": "CellComp", "Trait Ontology": "TO",
+            "PlantOntologyTerm": "PO", "Enzyme Classification": "EC",
+            "Quantitative Trait Locus": "QTL", "Protein Domain": "Domain"};
         result = map[conText];
         // If result is not null, return result, else return conText
         return result != null ? result : conText;
@@ -34,46 +28,94 @@ KNETMAPS.ConceptsLegend = function () {
 
         var conceptsHashmap = {};
         conceptTypes.forEach(function (conType, index) {
-            var conCount = conNodes.filterFn(function (ele) {
+            // Get the total number of concepts for that concept 
+            var totConCount = conNodes.filterFn(function (ele) {
                 return ele.data('conceptType') === conType;
             }).size();
-            // Push count of concepts of this Type to concepts hashmap
-            conceptsHashmap[conType] = conCount;
+            // Get a collection of all the visible nodes and their length
+            var currently_visibleNodes = cy.collection();
+            conNodes.filter('node[conceptType="' + conType + '"]').forEach(function (conc) {
+                if (conc.hasClass('ShowEle')) {
+                    currently_visibleNodes = currently_visibleNodes.add(conc);
+                }
+            });
+            conceptsHashmap[conType] = ($(currently_visibleNodes).length + "/" + totConCount);
         });
-
         // update knetLegend.
         var knetLegend = '<div class="knetInteractiveLegend"><div class="knetLegend_row">' + '<div class="knetLegend_cell"><b>Interactive Legend:</b></div>';
         // Show concept Type icons (with total count displayed alongside).
         for (var con in conceptsHashmap) {
             var conText = KNETMAPS.ConceptsLegend().conName(con);
             knetLegend = knetLegend + '<div class="knetLegend_cell"><input type="submit" value="" id="' + con + '" title="Show or remove all ' + con.replace(/_/g, ' ') + '(s)" class="knetCon_' + con.replace(/ /g, '_') + '" style="vertical-align:middle" ontouchmove="KNETMAPS.ConceptsLegend().hideConnectedByType(this.id);" ondblclick="KNETMAPS.ConceptsLegend().hideConnectedByType(this.id);" onclick="KNETMAPS.ConceptsLegend().showConnectedByType(this.id);">' +
-                    conceptsHashmap[con] + '<span class="icon_caption">' + conText + '</span></div>';
+                    '<span class="icon_caption">' + conceptsHashmap[con] + '<br>' + conText + '</span></div>';
         }
         knetLegend = knetLegend + '</div></div>';
         $('#knetLegend').html(knetLegend); // update knetLegend
     }
 
+    my.nodeClassesOnGraph = function (cy, conType) {
+        // Obtain all hidden and currently visible nodes on the graph based upon the class they contain
+        var visibleNodes_ofSameType = hiddenNodes_ofSameType = currently_visibleNodes = cy.collection();
+        var conText = KNETMAPS.ConceptsLegend().conName(conType);
 
-    my.showConnectedByType = function (conType) {
-        // get all cytoscape elements via jQuery 
-        var cy = $('#cy').cytoscape('get');
-
-        var hiddenNodes_ofSameType = cy.collection();
-        // Get the nodes by concept type collection & iterate through them  and if concept is class 'HideEle', add the hiddenNodes collection.
+        // Filter by the type clicked by the user
         cy.nodes().filter('node[conceptType="' + conType + '"]').forEach(function (conc) {
+            // If the node has the class tag of "show element" then add it to the collection class
+            if (conc.hasClass('ShowEle')) {
+                visibleNodes_ofSameType = visibleNodes_ofSameType.add(conc);
+            }
             if (conc.hasClass('HideEle')) {
                 hiddenNodes_ofSameType = hiddenNodes_ofSameType.add(conc);
             }
         });
 
-        var currently_visibleNodes = cy.collection();
         cy.nodes().forEach(function (conc) {
+            // Only if the concept is visible
             if (conc.hasClass('ShowEle')) {
+                // Add to Cytoscape collection.
                 currently_visibleNodes = currently_visibleNodes.add(conc);
             }
         });
+        // Obtain all the count of all of the concepts within the graph of this type
+        var totConcepts = $(visibleNodes_ofSameType).length + $(hiddenNodes_ofSameType).length;
 
-        var conText = KNETMAPS.ConceptsLegend().conName(conType);
+        return {hiddenNodes: hiddenNodes_ofSameType, visibleNodes: currently_visibleNodes,
+            visibleOfSameType: visibleNodes_ofSameType, total: totConcepts, text: conText};
+    }
+
+    my.conceptCount = function (cy, conType, conText, totConcepts) {
+        // Update the name of the icon with the relevant counts accordingly
+        $(document).ready(function () {
+            var currentNodes_ofSameType = cy.collection();
+            cy.nodes().filter('node[conceptType="' + conType + '"]').forEach(function (conc) {
+                if (conc.hasClass('ShowEle')) {
+                    currentNodes_ofSameType = currentNodes_ofSameType.add(conc);
+                }
+            });
+            // Update the name with the current nodes / total nodes and the node type name. 
+            var nameToUpdate = " " + $(currentNodes_ofSameType).length + '\/' + totConcepts + '<br>' + conText;
+            $("span.icon_caption").each(function () {
+                if ($(this).text().includes(conText)) {
+                    $(this).html(nameToUpdate);
+                }
+            });
+            // If there's no nodes present of the same type then no error message should display anymore. 
+            if ($(currentNodes_ofSameType).length === 0) {
+                $('#infoDialog').html("");
+            }
+        });
+    }
+
+    my.showConnectedByType = function (conType) {
+        // get all cytoscape elements via jQuery 
+        var cy = $('#cy').cytoscape('get');
+        var collections = KNETMAPS.ConceptsLegend().nodeClassesOnGraph(cy, conType),
+                hiddenNodes_ofSameType = collections.hiddenNodes,
+                currently_visibleNodes = collections.visibleNodes,
+                conText = collections.text,
+                totConcepts = collections.total;
+
+        // end here
         var edge_count = $(hiddenNodes_ofSameType.edgesWith(currently_visibleNodes)).length;
         if (edge_count > 0) {
             // Display hidden nodes of same Type which are connected to currently visible Nodes.
@@ -85,59 +127,38 @@ KNETMAPS.ConceptsLegend = function () {
         }
 
         stats.updateKnetStats(); // Refresh network Stats.
-
-        $(document).ready(function () {
-            $("span.icon_caption").each(function () {
-                if ($(this).text() === conText) {
-                    return $(this).css({'color': '#2A2A2A', "font-weight": "normal"});
-                }
-            });
-        });
-
+        KNETMAPS.ConceptsLegend().conceptCount(cy, conType, conText, totConcepts); // Update the text count
     }
+
 
     my.hideConnectedByType = function (conType) {
         // get all cytoscape elements via jQuery 
         var cy = $('#cy').cytoscape('get');
-
         // Define the visible nodes of the same type as a Cytoscape collection
-        var visibleNodes_ofSameType = cy.collection();
-        // Filter by the type clicked by the user
-        cy.nodes().filter('node[conceptType="' + conType + '"]').forEach(function (conc) {
-            // If the node has the class tag of "show element" then add it to the collection class
-            if (conc.hasClass('ShowEle')) {
-                visibleNodes_ofSameType = visibleNodes_ofSameType.add(conc);
-            }
-        });
+        var collections = KNETMAPS.ConceptsLegend().nodeClassesOnGraph(cy, conType),
+                visibleNodes_ofSameType = collections.visibleOfSameType,
+                currently_visibleNodes = collections.visibleNodes,
+                conText = collections.text,
+                totConcepts = collections.total;
 
-        // Define a collection of nodes currently visible on the graph
-        var currently_visibleNodes = cy.collection();
-        cy.nodes().forEach(function (conc) {
-            // Only if the concept is visible
-            if (conc.hasClass('ShowEle')) {
-                // Add to Cytoscape collection.
-                currently_visibleNodes = currently_visibleNodes.add(conc);
-            }
-        });
-
-        // Set the collection of visible nodes to hidden and remove its show class, thus setting the CSS display to None.
-        visibleNodes_ofSameType.addClass('HideEle').removeClass('ShowEle');
-        // Repeat the same for the edges of the nodes; set their display to None. 
-        visibleNodes_ofSameType.edgesWith(currently_visibleNodes).addClass('HideEle').removeClass('ShowEle');
-
-        stats.updateKnetStats(); // Refresh network Stats.
-        var conText = KNETMAPS.ConceptsLegend().conName(conType);
-        $(document).ready(function () {
-            $("span.icon_caption").each(function () {
-                if ($(this).text() === conText) {
-                    return $(this).css({'color': 'red', "font-weight": "bold"});
+        var edge_count = $(visibleNodes_ofSameType.edgesWith(currently_visibleNodes)).length; // Obtain the number of edges present
+        // Ensure that Gene concepts cannot be removed. 
+        if (conText.includes("Gene") == false) {
+            // Set the collection of visible nodes to hidden and remove its show class, thus setting the CSS display to None.
+            cy.nodes().forEach(function (ele) {
+                if (ele.data('conceptType') === conType) {
+                    ele.removeClass('ShowEle').addClass('HideEle');
                 }
             });
-        });
-        var edge_count = $(visibleNodes_ofSameType.edgesWith(currently_visibleNodes)).length;
-        if (edge_count > 0) {
+            stats.updateKnetStats(); // Refresh network Stats.
+        } else if (conText.includes("Gene")) {
+            // Show appropriate error regarding user attempt to remove the Gene concept.
+            $('#infoDialog').html('<font color="red">' + "Can't remove  " + conText + " concept nodes.</font>").show();
+        } else if (edge_count > 0 && conText.includes("Gene") == false) {
             $('#infoDialog').html("");
         }
+
+        KNETMAPS.ConceptsLegend().conceptCount(cy, conType, conText, totConcepts); // Update the text count
     }
 
     return my;

--- a/common/client-base/src/main/webapp/html/KnetMaps/javascript/knet-conceptsLegend.js
+++ b/common/client-base/src/main/webapp/html/KnetMaps/javascript/knet-conceptsLegend.js
@@ -153,7 +153,15 @@ KNETMAPS.ConceptsLegend = function () {
             stats.updateKnetStats(); // Refresh network Stats.
         } else if (conText.includes("Gene")) {
             // Show appropriate error regarding user attempt to remove the Gene concept.
-            $('#infoDialog').html('<font color="red">' + "Can't remove  " + conText + " concept nodes.</font>").show();
+            cy.nodes().forEach(function (ele) {
+                if (ele.hasClass('FlaggedGene')) {
+                    $('#infoDialog').html('<font color="red">' + "Can't remove  the main Gene Concept node.</font>").show();
+                } else if (ele.data('conceptType') == conType) {
+                    ele.removeClass('ShowEle').addClass('HideEle');
+                    $('#infoDialog').html("");
+                    stats.updateKnetStats(); 
+                }
+            });
         } else if (edge_count > 0 && conText.includes("Gene") == false) {
             $('#infoDialog').html("");
         }

--- a/common/client-base/src/main/webapp/html/KnetMaps/javascript/knet-container.js
+++ b/common/client-base/src/main/webapp/html/KnetMaps/javascript/knet-container.js
@@ -1,346 +1,345 @@
 var KNETMAPS = KNETMAPS || {};
 
-KNETMAPS.Container = function() {
-	
+KNETMAPS.Container = function () {
 
-	var stats = KNETMAPS.Stats();
-	var iteminfo = KNETMAPS.ItemInfo();
 
-	var my = function() {};
-	
-my.load_reload_Network = function(network_json, network_style) {
+    var stats = KNETMAPS.Stats();
+    var iteminfo = KNETMAPS.ItemInfo();
+
+    var my = function () {};
+
+    my.load_reload_Network = function (network_json, network_style) {
 
 // Initialise a cytoscape container instance on the HTML DOM using JQuery.
-var cy = cytoscape({
-  container: document.getElementById('cy')/*$('#cy')*/,
-  style: network_style,
-  // Using the JSON data to create the nodes.
-  elements: network_json,
+        var cy = cytoscape({
+            container: document.getElementById('cy')/*$('#cy')*/,
+            style: network_style,
+            // Using the JSON data to create the nodes.
+            elements: network_json,
 //  layout: /*defaultNetworkLayout*/ coseNetworkLayout, // layout of the Network
 
-  // these options hide parts of the graph during interaction such as panning, dragging, etc. to enable faster rendering for larger graphs.
+            // these options hide parts of the graph during interaction such as panning, dragging, etc. to enable faster rendering for larger graphs.
 //  hideLabelsOnViewport: true,
 //  hideEdgesOnViewport: true,
 
-  // this is an alternative that uses a bitmap during interaction.
-  textureOnViewport: false, // true,
-  /* the colour of the area outside the viewport texture when initOptions.textureOnViewport === true can
-   * be set by: e.g., outside-texture-bg-color: white, */
+            // this is an alternative that uses a bitmap during interaction.
+            textureOnViewport: false, // true,
+            /* the colour of the area outside the viewport texture when initOptions.textureOnViewport === true can
+             * be set by: e.g., outside-texture-bg-color: white, */
 
-  // interpolate on high density displays instead of increasing resolution.
-  pixelRatio: 1,
+            // interpolate on high density displays instead of increasing resolution.
+            pixelRatio: 1,
 
-  // Zoom settings
-  zoomingEnabled: true, // zooming: both by user and programmatically.
+            // Zoom settings
+            zoomingEnabled: true, // zooming: both by user and programmatically.
 //  userZoomingEnabled: true, // user-enabled zooming.
-  zoom: 1, // the initial zoom level of the graph before the layout is set.
+            zoom: 1, // the initial zoom level of the graph before the layout is set.
 //  minZoom: 1e-50, maxZoom: 1e50,
-  /* mouse wheel sensitivity settings to enable a more gradual Zooming process. A value between 0 and 1 
-   * reduces the sensitivity (zooms slower) & a value greater than 1 increases the sensitivity. */
-  wheelSensitivity: 0.05,
+            /* mouse wheel sensitivity settings to enable a more gradual Zooming process. A value between 0 and 1 
+             * reduces the sensitivity (zooms slower) & a value greater than 1 increases the sensitivity. */
+            wheelSensitivity: 0.05,
 
-  panningEnabled: true, // panning: both by user and programmatically.
+            panningEnabled: true, // panning: both by user and programmatically.
 //  userPanningEnabled: true, // user-enabled panning.
 
-  // for Touch-based gestures.
+            // for Touch-based gestures.
 //  selectionType: (isTouchDevice ? 'additive' : 'single'),
-  touchTapThreshold: 8,
-  desktopTapThreshold: 4,
-  autolock: false,
-  autoungrabify: false,
-  autounselectify: false,
+            touchTapThreshold: 8,
+            desktopTapThreshold: 4,
+            autolock: false,
+            autoungrabify: false,
+            autounselectify: false,
 
-  // a "motion blur" effect that increases perceived performance for little or no cost.
-  motionBlur: true,
+            // a "motion blur" effect that increases perceived performance for little or no cost.
+            motionBlur: true,
 
-  ready: function() {
-	  KNETMAPS.Menu().rerunLayout(); // reset current layout.
-   window.cy= this;
-  }
-});
+            ready: function () {
+                KNETMAPS.Menu().rerunLayout(); // reset current layout.
+                window.cy = this;
+            }
+        });
 
 // Get the cytoscape instance as a Javascript object from JQuery.
 //var cy= $('#cy').cytoscape('get'); // now we have a global reference to `cy`
 
 // cy.boxSelectionEnabled(true); // enable box selection (highlight & select multiple elements for moving via mouse click and drag).
-cy.boxSelectionEnabled(false); // to disable box selection & hence allow Panning, i.e., dragging the entire graph.
+        cy.boxSelectionEnabled(false); // to disable box selection & hence allow Panning, i.e., dragging the entire graph.
 
 // Set requisite background image for each concept (node) instead of using cytoscapeJS shapes.
-/* cy.nodes().forEach(function( ele ) {
-  var conType= ele.data('conceptType');
-  var imgName= 'Gene'; // default
-  if(conType === "Biological_Process") {
-     imgName= 'Biological_process';
-    }
-  else if(conType === "Cellular_Component") {
-       imgName= 'Cellular_component';
-      }
-  else if(conType === "Gene") {
-       imgName= 'Gene';
-      }
-  else if(conType === "Protein Domain") {
-     imgName= 'Protein_domain';
-    }
-  else if(conType === "Pathway") {
-     imgName= 'Pathway';
-    }
-  else if(conType === "Reaction") {
-     imgName= 'Reaction';
-    }
-  else if(conType === "Publication") {
-     imgName= 'Publication';
-    }
-  else if(conType === "Protein") {
-     imgName= 'Protein';
-    }
-  else if(conType === "Quantitative Trait Locus") {
-     imgName= 'QTL';
-    }
-  else if(conType === "Enzyme") {
-     imgName= 'Enzyme';
-    }
-  else if(conType === "Molecular_Function") {
-     imgName= 'Molecular_function';
-    }
-  else if((conType === "Enzyme_Classification") || (conType === "Enzyme Classification")) {
-     imgName= 'Enzyme_classification';
-    }
-  else if(conType === "Trait Ontology") {
-     imgName= 'Trait_ontology';
-    }
-  else if(conType === "Scaffold") {
-     imgName= 'Scaffold';
-    }
-  else if((conType === "Compound") || (conType === "SNP")) {
-     imgName= 'Compound';
-    }
-  else if(conType === "Phenotype") {
-     imgName= 'Phenotype';
-    }
-  var eleImage= 'image/'+ imgName +'.png';
-//  var eleImage= data_url +'image/'+ imgName +'.png';
+        /* cy.nodes().forEach(function( ele ) {
+         var conType= ele.data('conceptType');
+         var imgName= 'Gene'; // default
+         if(conType === "Biological_Process") {
+         imgName= 'Biological_process';
+         }
+         else if(conType === "Cellular_Component") {
+         imgName= 'Cellular_component';
+         }
+         else if(conType === "Gene") {
+         imgName= 'Gene';
+         }
+         else if(conType === "Protein Domain") {
+         imgName= 'Protein_domain';
+         }
+         else if(conType === "Pathway") {
+         imgName= 'Pathway';
+         }
+         else if(conType === "Reaction") {
+         imgName= 'Reaction';
+         }
+         else if(conType === "Publication") {
+         imgName= 'Publication';
+         }
+         else if(conType === "Protein") {
+         imgName= 'Protein';
+         }
+         else if(conType === "Quantitative Trait Locus") {
+         imgName= 'QTL';
+         }
+         else if(conType === "Enzyme") {
+         imgName= 'Enzyme';
+         }
+         else if(conType === "Molecular_Function") {
+         imgName= 'Molecular_function';
+         }
+         else if((conType === "Enzyme_Classification") || (conType === "Enzyme Classification")) {
+         imgName= 'Enzyme_classification';
+         }
+         else if(conType === "Trait Ontology") {
+         imgName= 'Trait_ontology';
+         }
+         else if(conType === "Scaffold") {
+         imgName= 'Scaffold';
+         }
+         else if((conType === "Compound") || (conType === "SNP")) {
+         imgName= 'Compound';
+         }
+         else if(conType === "Phenotype") {
+         imgName= 'Phenotype';
+         }
+         var eleImage= 'image/'+ imgName +'.png';
+         //  var eleImage= data_url +'image/'+ imgName +'.png';
+         
+         // Add these properties to this element's JSON.
+         ele.data('nodeImage', eleImage);
+         //  console.log("data.nodeImage "+ ele.data('nodeImage'));
+         });
+         
+         // Update the stylesheet for the Network Graph to show background images for Nodes.
+         cy.style().selector('node').css({ // Show actual background images.
+         'background-image': 'data(nodeImage)',
+         'background-fit': 'none' // can be 'none' (for original size), 'contain' (to fit inside node) or 'cover' (to cover the node).
+         }).update();
+         */
 
-  // Add these properties to this element's JSON.
-  ele.data('nodeImage', eleImage);
-//  console.log("data.nodeImage "+ ele.data('nodeImage'));
- });
+        /** Add a Qtip message to all the nodes & edges using QTip displaying their Concept Type & value when a 
+         * node/ edge is clicked.
+         * Note: Specify 'node' or 'edge' to bind an event to a specific type of element.
+         * e.g, cy.elements('node').qtip({ }); or cy.elements('edge').qtip({ }); */
+        cy.elements().qtip({
+            content: function () {
+                var qtipMsg = "";
+                try {
+                    if (this.isNode()) {
+                        qtipMsg = "<b>Concept:</b> " + this.data('value') + "<br/><b>Type:</b> " + this.data('conceptType');
+                    } else if (this.isEdge()) {
+                        qtipMsg = "<b>Relation:</b> " + this.data('label');
+                        var fromID = this.data('source'); // relation source ('fromConcept')
+                        qtipMsg = qtipMsg + "<br/><b>From:</b> " + cy.$('#' + fromID).data('value') + " (" + cy.$('#' + fromID).data('conceptType').toLowerCase() + ")";
+                        var toID = this.data('target'); // relation source ('toConcept')
+                        qtipMsg = qtipMsg + "<br/><b>To:</b> " + cy.$('#' + toID).data('value') + " (" + cy.$('#' + toID).data('conceptType').toLowerCase() + ")";
+                    }
+                } catch (err) {
+                    qtipMsg = "Selected element is neither a Concept nor a Relation";
+                }
+                return qtipMsg;
+            },
+            style: {
+                classes: 'qtip-bootstrap',
+                tip: {
+                    width: 12,
+                    height: 6
+                }
+            }
+        });
 
- // Update the stylesheet for the Network Graph to show background images for Nodes.
- cy.style().selector('node').css({ // Show actual background images.
-           'background-image': 'data(nodeImage)',
-           'background-fit': 'none' // can be 'none' (for original size), 'contain' (to fit inside node) or 'cover' (to cover the node).
-          }).update();
-*/
-
-/** Add a Qtip message to all the nodes & edges using QTip displaying their Concept Type & value when a 
- * node/ edge is clicked.
- * Note: Specify 'node' or 'edge' to bind an event to a specific type of element.
- * e.g, cy.elements('node').qtip({ }); or cy.elements('edge').qtip({ }); */
-cy.elements().qtip({
-  content: function() {
-     var qtipMsg= "";
-     try {
-      if(this.isNode()) {
-         qtipMsg= "<b>Concept:</b> "+ this.data('value') +"<br/><b>Type:</b> "+ this.data('conceptType');
-        }
-      else if(this.isEdge()) {
-              qtipMsg= "<b>Relation:</b> "+ this.data('label');
-              var fromID= this.data('source'); // relation source ('fromConcept')
-              qtipMsg= qtipMsg +"<br/><b>From:</b> "+ cy.$('#'+fromID).data('value') +" ("+ cy.$('#'+fromID).data('conceptType').toLowerCase() +")";
-              var toID= this.data('target'); // relation source ('toConcept')
-              qtipMsg= qtipMsg +"<br/><b>To:</b> "+ cy.$('#'+toID).data('value') +" ("+ cy.$('#'+toID).data('conceptType').toLowerCase() +")";
-             }
-      }
-      catch(err) { qtipMsg= "Selected element is neither a Concept nor a Relation"; }
-      return qtipMsg;
-     },
-  style: {
-    classes: 'qtip-bootstrap',
-    tip: {
-      width: 12,
-      height: 6
-    }
-  }
-});
-
-/** Event handling: mouse 'tap' event on all the elements of the core (i.e., the cytoscape container).
- * Note: Specify 'node' or 'edge' to bind an event to a specific type of element.
- * e.g, cy.on('tap', 'node', function(e){ }); or cy.on('tap', 'edge', function(e){ }); */
- cy.on('tap', function(e) {
-    var thisElement= e.cyTarget;
-    var info= "";
-    try {
-    if(thisElement.isNode()) {
-       info= "<b>Concept:</b> "+ thisElement.data('value') +"<br/><b>Type:</b> "+ thisElement.data('conceptType');
-      }
-      else if(thisElement.isEdge()) {
-              info= "<b>Relation:</b> "+ this.data('label');
-              var fromID= this.data('source'); // relation source ('fromConcept')
-              info= info +"<br/><b>From:</b> "+ cy.$('#'+fromID).data('value') +" ("+ cy.$('#'+fromID).data('conceptType').toLowerCase();
-              var toID= this.data('target'); // relation source ('toConcept')
-              info= info +"<br/><b>To:</b> "+ cy.$('#'+toID).data('value') +" ("+ cy.$('#'+toID).data('conceptType').toLowerCase() +")";
-             }
-      }
-      catch(err) { info= "Selected element is neither a Concept nor a Relation"; }
-    console.log(info);
-    iteminfo.showItemInfo(thisElement);
-   });
+        /** Event handling: mouse 'tap' event on all the elements of the core (i.e., the cytoscape container).
+         * Note: Specify 'node' or 'edge' to bind an event to a specific type of element.
+         * e.g, cy.on('tap', 'node', function(e){ }); or cy.on('tap', 'edge', function(e){ }); */
+        cy.on('tap', function (e) {
+            var thisElement = e.cyTarget;
+            var info = "";
+            try {
+                if (thisElement.isNode()) {
+                    info = "<b>Concept:</b> " + thisElement.data('value') + "<br/><b>Type:</b> " + thisElement.data('conceptType');
+                } else if (thisElement.isEdge()) {
+                    info = "<b>Relation:</b> " + this.data('label');
+                    var fromID = this.data('source'); // relation source ('fromConcept')
+                    info = info + "<br/><b>From:</b> " + cy.$('#' + fromID).data('value') + " (" + cy.$('#' + fromID).data('conceptType').toLowerCase();
+                    var toID = this.data('target'); // relation source ('toConcept')
+                    info = info + "<br/><b>To:</b> " + cy.$('#' + toID).data('value') + " (" + cy.$('#' + toID).data('conceptType').toLowerCase() + ")";
+                }
+            } catch (err) {
+                info = "Selected element is neither a Concept nor a Relation";
+            }
+            console.log(info);
+            iteminfo.showItemInfo(thisElement);
+        });
 // cxttap - normalised right click or 2-finger tap event.
 
- /** Popup (context) menu: a circular Context Menu for each Node (concept) & Edge (relation) using the 'cxtmenu' jQuery plugin. */
- var contextMenu= {
-    menuRadius: 75, // the radius of the circular menu in pixels
+        /** Popup (context) menu: a circular Context Menu for each Node (concept) & Edge (relation) using the 'cxtmenu' jQuery plugin. */
+        var contextMenu = {
+            menuRadius: 75, // the radius of the circular menu in pixels
 
-    // Use selector: '*' to set this circular Context Menu on all the elements of the core.
-    /** Note: Specify selector: 'node' or 'edge' to restrict the context menu to a specific type of element. e.g, 
-     * selector: 'node', // to have context menu only for nodes.
-     * selector: 'edge', // to have context menu only for edges. */
-    selector: '*',
-    commands: [ // an array of commands to list in the menu
-        {
-         content: 'Show Info',
-         select: function() {
-             // Show Item Info Pane.
-        	 iteminfo.openItemInfoPane();
+            // Use selector: '*' to set this circular Context Menu on all the elements of the core.
+            /** Note: Specify selector: 'node' or 'edge' to restrict the context menu to a specific type of element. e.g, 
+             * selector: 'node', // to have context menu only for nodes.
+             * selector: 'edge', // to have context menu only for edges. */
+            selector: '*',
+            commands: [// an array of commands to list in the menu
+                {
+                    content: 'Show Info',
+                    select: function () {
+                        // Show Item Info Pane.
+                        iteminfo.openItemInfoPane();
 
-             // Display Item Info.
-        	 iteminfo.showItemInfo(this);
-            }
-        },
-            
-        {
-         content: 'Show Links',
-         select: function() {
-             if(this.isNode()) {
-            	 iteminfo.showLinks(this);
-                // Refresh network legend.
-                stats.updateKnetStats();
-               }
-           }
-        },
-
-        {
-         content: 'Hide',
-         select: function() {
-             //this.hide(); // hide the selected 'node' or 'edge' element.
-             this.removeClass('ShowEle');
-             this.addClass('HideEle');
-             // Refresh network legend.
-             stats.updateKnetStats();
-            }
-        },
-
-        {
-         content: 'Hide by Type',
-         select: function() { // Hide all concepts (nodes) of the same type.
-             if(this.isNode()) {
-                var thisConceptType= this.data('conceptType');
-        //        console.log("Hide Concept by Type: "+ thisConceptType);
-                cy.nodes().forEach(function( ele ) {
-                 if(ele.data('conceptType') === thisConceptType && thisConceptType.includes("Gene") == false) {
-                    //ele.hide();
-                    ele.removeClass('ShowEle');
-                    ele.addClass('HideEle');
-                    $('#infoDialog').html("");
-                   }
-                   if(thisConceptType.includes("Gene")){
-                      $('#infoDialog').html('<font color="red">' + "Can't remove  " + thisConceptType + " concept nodes.</font>").show();
-                   }
-                });
-                // Relayout the graph.
-                //rerunLayout();
-               }
-             else if(this.isEdge()) { // Hide all relations (edges) of the same type.
-                var thisRelationType= this.data('label');
-        //        console.log("Hide Relation (by Label type): "+ thisRelationType);
-                cy.edges().forEach(function( ele ) {
-                 if(ele.data('label') === thisRelationType) {
-                    //ele.hide();
-                    ele.removeClass('ShowEle');
-                    ele.addClass('HideEle');
-                   }
-                });
-                // Relayout the graph.
-               // rerunLayout();
-               }
-            // Refresh network Stats.
-            stats.updateKnetStats();
-           }
-        },
-
-        {
-         content: 'Label on/ off by Type',
-         select: function() {
-             var thisElementType, eleType, elements;
-             if(this.isNode()) {
-                thisElementType= this.data('conceptType'); // get all concept Types.
-                eleType= 'conceptType';
-                elements= cy.nodes(); // fetch all the nodes.
-               }
-             else if(this.isEdge()) {
-                thisElementType= this.data('label'); // get all relation Labels.
-                eleType= 'label';
-                elements= cy.edges(); // fetch all the edges.
-               }
-
-                if(this.hasClass("LabelOff")) {  // show the concept/ relation Label.
-                   elements.forEach(function( ele ) {
-                    if(ele.data(eleType) === thisElementType) { // for same concept or relation types
-                       if(ele.hasClass("LabelOff")) {
-                          ele.removeClass("LabelOff");
-                          ele.addClass("LabelOn");
-                         }
-                      }
-                   });
-                  }
-                  else if(this.hasClass("LabelOn")) { // hide the concept/ relation Label.
-                      elements.forEach(function( ele ) {
-                       if(ele.data(eleType) === thisElementType) { // for same concept or relation types
-                          if(ele.hasClass("LabelOn")) {
-                             ele.removeClass("LabelOn");
-                             ele.addClass("LabelOff");
-                            }
-                         }
-                      });
+                        // Display Item Info.
+                        iteminfo.showItemInfo(this);
                     }
-            }
-        },
+                },
 
-        {
-         content: 'Label on/ off',
-         select: function() {
-             if(this.hasClass("LabelOff")) {  // show the concept/ relation Label.
-                this.removeClass("LabelOff");
-                this.addClass("LabelOn");
-               }
-             else if(this.hasClass("LabelOn")) {  // hide the concept/ relation Label.
-                this.removeClass("LabelOn");
-                this.addClass("LabelOff");
-               }
-            }
-        }
-    ], 
-    fillColor: 'rgba(0, 0, 0, 0.75)', // the background colour of the menu
-    activeFillColor: 'rgba(92, 194, 237, 0.75)', // the colour used to indicate the selected command
-    activePadding: 2, // 20, // additional size in pixels for the active command
-    indicatorSize: 15, // 24, // the size in pixels of the pointer to the active command
-    separatorWidth: 3, // the empty spacing in pixels between successive commands
-    spotlightPadding: 3, // extra spacing in pixels between the element and the spotlight
-    minSpotlightRadius: 5, // 24, // the minimum radius in pixels of the spotlight
-    maxSpotlightRadius: 10, // 38, // the maximum radius in pixels of the spotlight
-    itemColor: 'white', // the colour of text in the command's content
-    itemTextShadowColor: 'black', // the text shadow colour of the command's content
-    zIndex: 9999 // the z-index of the ui div
- };
+                {
+                    content: 'Show Links',
+                    select: function () {
+                        if (this.isNode()) {
+                            iteminfo.showLinks(this);
+                            // Refresh network legend.
+                            stats.updateKnetStats();
+                        }
+                    }
+                },
 
-cy.cxtmenu(contextMenu); // set Context Menu for all the core elements.
+                {
+                    content: 'Hide',
+                    select: function () {
+                        //this.hide(); // hide the selected 'node' or 'edge' element.
+                        if (this.hasClass('FlaggedGene')) {
+                            $('#infoDialog').html('<font color="red">' + "Can't remove  the main Gene Concept node.</font>").show();
+                        } else {
+                            this.removeClass('ShowEle');
+                            this.addClass('HideEle');
+                            // Refresh network legend.
+                            stats.updateKnetStats();
+                        }
+                    }
+                },
 
- // Show the popup Info. dialog box.
- $('#infoDialog').click(function() {
-   $('#infoDialog').slideToggle(300);
-  });
+                {
+                    content: 'Hide by Type',
+                    select: function () { // Hide all concepts (nodes) of the same type.
+                        if (this.isNode()) {
+                            var thisConceptType = this.data('conceptType');
+                            //        console.log("Hide Concept by Type: "+ thisConceptType);
+                            cy.nodes().forEach(function (ele) {
+                                if (ele.data('conceptType') === thisConceptType && !ele.hasClass('FlaggedGene')) {
+                                    //ele.hide();
+                                    ele.removeClass('ShowEle').addClass('HideEle');
+                                    $('#infoDialog').html("");
+                                }
+                                if (ele.hasClass('FlaggedGene')) {
+                                    $('#infoDialog').html('<font color="red">' + "Can't remove  the main Gene Concept node.</font>").show();
+                                }
+                            });
+                            // Relayout the graph.
+                            //rerunLayout();
+                        } else if (this.isEdge()) { // Hide all relations (edges) of the same type.
+                            var thisRelationType = this.data('label');
+                            //        console.log("Hide Relation (by Label type): "+ thisRelationType);
+                            cy.edges().forEach(function (ele) {
+                                if (ele.data('label') === thisRelationType) {
+                                    //ele.hide();
+                                    ele.removeClass('ShowEle');
+                                    ele.addClass('HideEle');
+                                }
+                            });
+                            // Relayout the graph.
+                            // rerunLayout();
+                        }
+                        // Refresh network Stats.
+                        stats.updateKnetStats();
+                    }
+                },
 
-}
+                {
+                    content: 'Label on/ off by Type',
+                    select: function () {
+                        var thisElementType, eleType, elements;
+                        if (this.isNode()) {
+                            thisElementType = this.data('conceptType'); // get all concept Types.
+                            eleType = 'conceptType';
+                            elements = cy.nodes(); // fetch all the nodes.
+                        } else if (this.isEdge()) {
+                            thisElementType = this.data('label'); // get all relation Labels.
+                            eleType = 'label';
+                            elements = cy.edges(); // fetch all the edges.
+                        }
 
-return my;
+                        if (this.hasClass("LabelOff")) {  // show the concept/ relation Label.
+                            elements.forEach(function (ele) {
+                                if (ele.data(eleType) === thisElementType) { // for same concept or relation types
+                                    if (ele.hasClass("LabelOff")) {
+                                        ele.removeClass("LabelOff");
+                                        ele.addClass("LabelOn");
+                                    }
+                                }
+                            });
+                        } else if (this.hasClass("LabelOn")) { // hide the concept/ relation Label.
+                            elements.forEach(function (ele) {
+                                if (ele.data(eleType) === thisElementType) { // for same concept or relation types
+                                    if (ele.hasClass("LabelOn")) {
+                                        ele.removeClass("LabelOn");
+                                        ele.addClass("LabelOff");
+                                    }
+                                }
+                            });
+                        }
+                    }
+                },
+
+                {
+                    content: 'Label on/ off',
+                    select: function () {
+                        if (this.hasClass("LabelOff")) {  // show the concept/ relation Label.
+                            this.removeClass("LabelOff");
+                            this.addClass("LabelOn");
+                        } else if (this.hasClass("LabelOn")) {  // hide the concept/ relation Label.
+                            this.removeClass("LabelOn");
+                            this.addClass("LabelOff");
+                        }
+                    }
+                }
+            ],
+            fillColor: 'rgba(0, 0, 0, 0.75)', // the background colour of the menu
+            activeFillColor: 'rgba(92, 194, 237, 0.75)', // the colour used to indicate the selected command
+            activePadding: 2, // 20, // additional size in pixels for the active command
+            indicatorSize: 15, // 24, // the size in pixels of the pointer to the active command
+            separatorWidth: 3, // the empty spacing in pixels between successive commands
+            spotlightPadding: 3, // extra spacing in pixels between the element and the spotlight
+            minSpotlightRadius: 5, // 24, // the minimum radius in pixels of the spotlight
+            maxSpotlightRadius: 10, // 38, // the maximum radius in pixels of the spotlight
+            itemColor: 'white', // the colour of text in the command's content
+            itemTextShadowColor: 'black', // the text shadow colour of the command's content
+            zIndex: 9999 // the z-index of the ui div
+        };
+
+        cy.cxtmenu(contextMenu); // set Context Menu for all the core elements.
+
+        // Show the popup Info. dialog box.
+        $('#infoDialog').click(function () {
+            $('#infoDialog').slideToggle(300);
+        });
+
+    }
+
+    return my;
 };

--- a/common/client-base/src/main/webapp/html/KnetMaps/javascript/knet-container.js
+++ b/common/client-base/src/main/webapp/html/KnetMaps/javascript/knet-container.js
@@ -237,10 +237,14 @@ cy.elements().qtip({
                 var thisConceptType= this.data('conceptType');
         //        console.log("Hide Concept by Type: "+ thisConceptType);
                 cy.nodes().forEach(function( ele ) {
-                 if(ele.data('conceptType') === thisConceptType) {
+                 if(ele.data('conceptType') === thisConceptType && thisConceptType.includes("Gene") == false) {
                     //ele.hide();
                     ele.removeClass('ShowEle');
                     ele.addClass('HideEle');
+                    $('#infoDialog').html("");
+                   }
+                   if(thisConceptType.includes("Gene")){
+                      $('#infoDialog').html('<font color="red">' + "Can't remove  " + thisConceptType + " concept nodes.</font>").show();
                    }
                 });
                 // Relayout the graph.


### PR DESCRIPTION
RE: https://github.com/Rothamsted/knetmaps.js/issues/8

Modified so that 'FlaggedGene' concepts, which are central to KNs, can't be removed - Genes can be added & removed now. Now updates concept counts accordingly and shows the correct total e.g. 1/10 Publications. Also resolved a minor bug within knet-containerLegend.js regarding edges.Please see below image:

![Selection_024](https://user-images.githubusercontent.com/47788638/63790516-575e9280-c8f1-11e9-9eef-bf1f8b756370.png)
