### PR TITLE
muti-species first draft #635

### DIFF
--- a/aratiny/aratiny-client/src/main/webapp/html/javascript/utils-config.js
+++ b/aratiny/aratiny-client/src/main/webapp/html/javascript/utils-config.js
@@ -4,6 +4,7 @@ var api_url = "${knetminer.api.url}";
 // boolean, tells if the data set contains reference genome info  
 var reference_genome = ${knetminer.isReferenceGenomeProvided};
 var multiorganisms = false; // Code support the multi-organism case, but now it's disabled
+// TODO : to be removed to support multi-orgamism case
 var species_name = "${knetminer.specieName}";
 var knetspace_api_host= "${knetminer.knetSpaceHost}"; // from base knetminer POM for client-side JS
 var enforce_genelist_limit= true; // enforce free user search limits (true/false).
@@ -11,3 +12,4 @@ var freegenelist_limit= 20; // default gene list search limit for free user (Pro
 var knetview_limit= 10; // default Gene View knetwork selction limit for KnetMaps for Free user (Pro: 200).
 var enableGA = "${knetminer.enableAnalytics}"; // from base knetminer POM for client-side JS to use
 var ga_id = "${knetminer.gaIdUi}"; // ga_id from base knetminer POM for UI JS to use
+var taxnomyUrl = "https://rest.ensembl.org/taxonomy/id/"

--- a/client-base/src/main/webapp/WEB-INF/tags/layout/content.tag
+++ b/client-base/src/main/webapp/WEB-INF/tags/layout/content.tag
@@ -9,7 +9,16 @@
 	<div id="search">
 		<form id="gviewerForm" name="gviewerForm" action="javascript:searchKeyword()" accept-charset="UTF-8">
 			<ul id="main_list">
-				<li>
+				<li style="position: relative;">
+
+					<div id="species_container" class="details">
+							<div class="detail_info">
+							<div>
+							<h4 style="margin:10px 0;">Specie description</h4></div>
+							<div id="speciename_container"></div>
+							</div>
+					</div>
+
                     <!-- Sample Queries -->
                     <div id="info" class="details">
                         <c:if test="${embeddable}"><div class="species_header"></div></c:if>

--- a/client-base/src/main/webapp/WEB-INF/tags/layout/header.tag
+++ b/client-base/src/main/webapp/WEB-INF/tags/layout/header.tag
@@ -3,9 +3,15 @@
 <div id="header">
 	<nav class="navbar navbar-default navbar-fixed-top" role="navigation">	
     	<a href="/" title="KnetMiner Home"><img class="logo-top" src="html/image/KnetMiner_green_white.svg" alt="Logo" height="45" style="padding-top:3px; padding-bottom:2px; padding-left:12px;"></a>
-                <a id="login_icon" title="Sign in"></a>
-                <a id="profile_icon" title="Profile"><i class="fa fa-user" aria-hidden="true"></i></a>
- 		<div id="species_header"></div>
+ 	<ul class="navbar-items">
 		<a id="release_icon" target="_blank" href="html/release.html" title="Release Notes"><i class="fa fa-pie-chart" aria-hidden="true"></i></a>
+		<div id="species_header">
+			<select class="navbar-select"></select>
+		</div>
+		<div class="login_container">
+			<a id="login_icon" title="Sign in"></a>
+        	<a id="profile_icon" title="Profile"><i class="fa fa-user" aria-hidden="true"></i></a>
+		</div>
+	 </ul>
 	</nav>
 </div>

--- a/client-base/src/main/webapp/WEB-INF/tags/layout/page.tag
+++ b/client-base/src/main/webapp/WEB-INF/tags/layout/page.tag
@@ -104,6 +104,9 @@
             <!-- evidence table -->
          <script type="text/javascript" src="html/javascript/evidence-table.js"></script>
 
+          <!-- multi species file -->
+         <script type="text/javascript" src="html/javascript/multispecies.js"></script>
+
          <!-- UI utils  -->
         <script type="text/javascript" src="html/javascript/ui-utils.js"></script>
 

--- a/client-base/src/main/webapp/html/css/loginStyle.css
+++ b/client-base/src/main/webapp/html/css/loginStyle.css
@@ -5,8 +5,6 @@
 
 #login_icon {
     float: right; 
-    padding-right: 15px; 
-    padding-top: 18px; 
     font-size: 20px;
     color: white;
 }
@@ -15,11 +13,9 @@
  
 #profile_icon {
     float: right; 
-    padding-right: 10px; 
-    padding-top: 18px; 
     font-size: 20px;
     color:#51CE7B;
-    /*color: orange;*/
+    margin-right: 6px;
 }
 
 #KnetSubmit, #KnetSpacelogin {
@@ -210,4 +206,9 @@ a {
     text-decoration:none;
     color:#51CE7B;
     /*color:darkorange;*/
+}
+
+
+.login_container{
+  margin-right:24px;
 }

--- a/client-base/src/main/webapp/html/css/style.css
+++ b/client-base/src/main/webapp/html/css/style.css
@@ -57,19 +57,10 @@ a img {
 }
 #release_icon {
     float: right; 
-    padding-right: 10px; 
-    padding-top: 18px; 
     font-size: 22px;
 }
 
-#species_header {
-    float: right;
-    color: white;
-    font-size: 20px;
-    font-style: italic;
-    padding-right: 20px;
-    padding-top: 18px;
-}
+
 a:hover {
     text-decoration:underline;
 }
@@ -156,12 +147,14 @@ div#leftnav {
     padding-top: 15px;
 }
 /*Navbar*/
-
+ 
 .navbar {
-    display:block;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
     height:57px;
-    box-shadow: 0 1px 1px white;
-    background-color:#121212 /*#2A2A2A*/;
+    box-shadow: rgba(99, 97, 97, 0.45) 0px 25px 20px -20px;
+    background-color:#121212;
     position: fixed;
     overflow: auto;
     z-index: 10;
@@ -975,7 +968,11 @@ a { cursor: pointer; }
 .reseticon{
     margin-right:0.5rem;
 }
-.counttext {font-size:12px; color:#9B9B9B; padding-bottom:10px; padding-top:10px;}
+.counttext {
+font-size:12px; 
+color:#9B9B9B; 
+padding-bottom:10px; 
+padding-top:10px;}
 
 
 /* reducing table height for smaller screen, this allow create network button to be above the fold */
@@ -1027,3 +1024,83 @@ a { cursor: pointer; }
     margin-bottom: 0.25rem;
     font-size: 12px;
 }
+
+
+/* styles for multi-specie knetminer */
+
+/* dropdown select */
+
+
+#species_header {
+    position: relative;
+    height: 70%;
+    width: 31%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 2rem;
+    margin-left: 0.5rem;
+    color: white;
+}
+
+#species_header::after {
+    content:'▾';
+    font-size: 1rem;
+    top: 10px;
+    right: 10px;
+    position: absolute;
+    z-index: 0;
+  }
+
+.navbar-select{
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    margin: 0;
+    height: 100%;
+    background: transparent;
+    border: 0.8px solid white;
+    border-radius: 6px;
+    color: white;
+    padding-left: 10px;
+    outline: none;
+    z-index: 10;
+}
+
+.navbar-items{
+    display: flex;
+    align-items: center;
+    width: 44%;
+    height: 100%;
+    justify-content:flex-end;
+}
+
+#species_container{
+    position: absolute;
+    right: 0pc;
+    top: 9pc;
+}
+
+.detail_info{
+    height: auto;
+    padding: 10px;
+}
+
+.specie_container{
+    display: flex;
+    align-items: center;
+    margin: 10px 0;
+    flex-wrap: wrap;
+}
+
+.specie_title{
+    color: #51CE7B;
+    font-weight: 400;
+    margin:0;
+    margin-right:10px;
+}
+
+
+
+
+

--- a/client-base/src/main/webapp/html/javascript/init-utils.js
+++ b/client-base/src/main/webapp/html/javascript/init-utils.js
@@ -22,8 +22,8 @@ function showReferenceGenome(){
 // function runs on page jquery document ready
 function loadOnReady(){
 
-     // add species name to header
-     $('#species_header').text(species_name); //update species name from utils_config.js
+  // add species name to header
+  //  $('#species_header').text(species_name); //update species name from utils_config.js
 
     activateResetButton(); 
 
@@ -41,6 +41,14 @@ function loadOnReady(){
     generalPageAnalytics(); 
 
     genemap.draw('#genemap', 'html/data/basemap.xml', null);
+
+   
+
+}
+
+// function to get text id name
+function createMultiSpecieSelect(){
+
 
 }
 
@@ -311,6 +319,10 @@ function bodyHandlers(){
         $('div.tooltip').remove();
     });
 }
+
+
+
+
 
 
 

--- a/client-base/src/main/webapp/html/javascript/multispecies.js
+++ b/client-base/src/main/webapp/html/javascript/multispecies.js
@@ -1,0 +1,86 @@
+
+
+//this is a mock data section that will be replaced by the species API
+// data will be generated as a variable through a function that calls the species api 
+// for example var species = getSpecieList()
+var getSpeciesList = [
+    {
+        "name":"arabidopsis",
+        "background": "./datasets/arabidopsis/client/background.jpg",
+        "taxId": 3702
+    }, 
+    {
+        "name":"wheat",
+        "background": "./datasets/arabidopsis/client/background.jpg",
+        "taxId": 4565
+    }, 
+    { 
+        "name":"maize",
+        "background": "./datasets/arabidopsis/client/background.jpg",
+        "taxId": 4577
+    }
+]
+
+/*
+ * Function Generates Species information through Ensembl get request API
+ */
+function getEnsemblList(){
+    // Ensembl REST API to fetch scientific and common name
+
+    var speciesNames = []; 
+    for(var i=0; i < getSpeciesList.length; i++){
+         var EnsemblIdkey = getSpeciesList[i].taxId;
+
+        $.get(taxnomyUrl+EnsemblIdkey+'?content-type=application/json','').done( function(data){
+            speciesNames.push(data)
+            // check if speciesNames length equals the specie mock data length 
+            if(speciesNames.length === getSpeciesList.length ){
+                specieInfo(speciesNames);
+            }
+        }).fail(function (xhr,status,errorlog){
+            errorComponent('.nav',xhr,status,errorlog);
+        });
+    }
+}
+
+/*
+ * Function takes data from getEnsemblList function, sends data to createDropdown function and create the specie information block
+ */
+function specieInfo(speciesNames){
+
+    // variable returns a true to confirm if dropdown options have been created 
+    var createdDropDown = createDropdown(speciesNames); 
+    if(createdDropDown){
+        // selecting the first occuring option element and setting global taxonomy ID
+        // it's possible to make an element the default, as first child position is randomised because of the loop
+        currentTaxId =  $('.navbar-select:first-child').val();
+        var currentSpecieInfo = speciesNames.filter(specieInfo => specieInfo.id === currentTaxId)[0]; 
+        $('<div class="specie_container"><h4 class="specie_title">Taxonomy Id:</h4><span id="specie_title">'+currentSpecieInfo.id+'</span></div>').appendTo('#speciename_container');
+    
+        $('<div class="specie_container"><h4 class="specie_title">Latin name:</h4><span id="specie_name">'+currentSpecieInfo.scientific_name+'</span></div>').appendTo('#speciename_container');
+        var commonNames = currentSpecieInfo.tags.common_name.toString().replaceAll(',',', ')
+        $('<div class="specie_container"><h4 class="specie_title">Common name:</h4><span id="specie_commonname">'+commonNames+'</span></div>').appendTo('#speciename_container');
+    }
+}
+
+/*
+ * Function inserts select element options to DOM 
+ */
+function createDropdown(speciesNames){
+    var expectedOptions = speciesNames.length; 
+    for(var speciesName in speciesNames){
+        var singleSpecie = speciesNames[speciesName]; 
+        var optionElement = '<option value='+ singleSpecie.id+'>'+singleSpecie.name +'</option>'
+        $('.navbar-select').append(optionElement);
+        if($('.navbar-select option').length === expectedOptions){
+            return true
+        }
+    }
+}
+
+
+
+
+
+
+

--- a/client-base/src/main/webapp/html/javascript/utils.js
+++ b/client-base/src/main/webapp/html/javascript/utils.js
@@ -12,6 +12,7 @@ var knetmaps = KNETMAPS.KnetMaps();
 */
 $(document).ready(
     function () {
+        getEnsemblList();
         loadOnReady();
         showReferenceGenome();
         initResetButton();
@@ -19,4 +20,7 @@ $(document).ready(
         QtlRegionHandlers();
         searchHandlers();
         bodyHandlers();
-    });
+        changeSpecie(); 
+        
+    }
+);


### PR DESCRIPTION
Commit contains the following implementations as requested  in issue #635 
- Rearranged the navbar by creating the multi-specie select dropdown element 
- Used sample/mock taxonomy ID to get species' common and scientific name using Ensembl-rest 
- Set global Taxonomy Id and added it to the Apis tested in issue #626 
- Implemented a specie block where current specie information is displayed. 
